### PR TITLE
Fix indentation for Gist code samples

### DIFF
--- a/assets/css/_partial/_single/_code.scss
+++ b/assets/css/_partial/_single/_code.scss
@@ -50,7 +50,7 @@ code, pre, .highlight table, .highlight tr, .highlight td {
       margin: 0;
       padding: 0;
       border: none !important;
-      white-space: nowrap;
+      white-space: pre;
     }
   }
 }


### PR DESCRIPTION
I modified the style used for rendering Gists in a post. The white-space
style was collapsing the white space at the beginning and end of the
line resulting in all code being left justified. I changed the style to
pre which preserves the whitespace and renders the Gist correctly.

Resolves #14 