### PR TITLE
add 'muted' shortcode from bootstrap

### DIFF
--- a/layouts/shortcodes/muted.html
+++ b/layouts/shortcodes/muted.html
@@ -1,0 +1,1 @@
+<small style="color: #6c757d !important;">{{.Inner | markdownify}}</small>


### PR DESCRIPTION
This PR adds the {{< muted >}} shortcode:

`Russian vodka is excellent! {{< muted >}}But drink responsibly!{{< /muted >}}`

This is inspired by bootstrap's `.text-muted`, which is one of its most-frequently used classes.