### PR TITLE
fix(posts): use existing .Site.Title parameter for title tag

### DIFF
--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -1,4 +1,4 @@
-{{- define "title" }}{{ .Title }} | {{ .Site.Params.Title }}{{ end -}}
+{{- define "title" }}{{ .Title }} | {{ .Site.Title }}{{ end -}}
 
 {{- define "dnsPrefetch" -}}
 {{- $params := .Scratch.Get "params" -}}


### PR DESCRIPTION
Fix a typo in posts title.

This can fix #117 